### PR TITLE
Ignore invalid quaternion.

### DIFF
--- a/move_base/src/move_base.cpp
+++ b/move_base/src/move_base.cpp
@@ -559,7 +559,7 @@ namespace move_base {
 
     if(fabs(dot - 1) > 1e-3){
       ROS_ERROR("Quaternion is invalid... for navigation the z-axis of the quaternion must be close to vertical.");
-      return false;
+    //  return false;
     }
 
     return true;

--- a/move_base/src/move_base.cpp
+++ b/move_base/src/move_base.cpp
@@ -550,6 +550,7 @@ namespace move_base {
       return false;
     }
 
+/*
     //next, we'll normalize the quaternion and check that it transforms the vertical vector correctly
     tf_q.normalize();
 
@@ -559,8 +560,9 @@ namespace move_base {
 
     if(fabs(dot - 1) > 1e-3){
       ROS_ERROR("Quaternion is invalid... for navigation the z-axis of the quaternion must be close to vertical.");
-    //  return false;
+      return false;
     }
+*/
 
     return true;
   }


### PR DESCRIPTION
We had to use this workaround in order to make the path following work with the new navigation stack. (I did not investigate why it happened, but it happened reproducibly at certain poses of the path)

You probably have a better idea how to fix it, feel free to decline this PR. ;)